### PR TITLE
fix NaN->nan issue for numpy 2.0

### DIFF
--- a/src/differences/attgt/attgt_cal.py
+++ b/src/differences/attgt/attgt_cal.py
@@ -303,7 +303,7 @@ def did_single_gt(
             cohort_stratum_dummy=None,
             stratum_dummy=None,
             exception=ex,
-            ATT=np.NaN,  # att, need nan to do some operations
+            ATT=np.nan,  # att, need nan to do some operations
             influence_func=None,
         )
 
@@ -476,7 +476,7 @@ def get_standard_errors(
 
     # create an empty array to populate with the standard errors
     se_array = np.empty(len(ntl))
-    se_array[:] = np.NaN
+    se_array[:] = np.nan
 
     if boot_iterations:
 

--- a/src/differences/attgt/difference.py
+++ b/src/differences/attgt/difference.py
@@ -392,7 +392,7 @@ def output_difference_namedtuple(
     # fill the last entries with NAs if missing
     if missing:
         missing = 4  # std_error, lower, upper, boot_iterations
-        args = *args, *[np.NaN] * missing
+        args = *args, *[np.nan] * missing
 
     nt = namedtuple(f"Difference{nt_name}", fields)
 

--- a/src/differences/attgt/utility.py
+++ b/src/differences/attgt/utility.py
@@ -78,7 +78,7 @@ def aggregation_namedtuple(
     missing = len(include_fields) - len(args)
     if missing:  # fill missing with NAs
         missing = 4  # std_error, lower, upper, boot_iterations
-        args = *args, *[np.NaN] * missing
+        args = *args, *[np.nan] * missing
 
     if type_of_aggregation == "simple" or overall:
         name = f"{type_of_aggregation.title()}Aggregation"


### PR DESCRIPTION
This moves `numpy.NaN` to `numpy.nan` for `numpy >= 2.0`. Functionality otherwise is unchanged. 